### PR TITLE
chore(knip): un-export internal-only symbols across lib/

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -12,6 +12,5 @@
     "lib/**/*.{ts,tsx}",
     "types/**/*.{ts,tsx}"
   ],
-  "ignoreExportsUsedInFile": true,
   "ignoreBinaries": ["vhs", "scripts/capture-weekly.sh", "scripts/frames-to-gif.sh"]
 }

--- a/lib/banners.ts
+++ b/lib/banners.ts
@@ -8,7 +8,7 @@ export type FeaturedBanner = {
   priority: number
 }
 
-export const BANNERS: FeaturedBanner[] = [
+const BANNERS: FeaturedBanner[] = [
   {
     id: 'w19-tuesday-reads-2026-05-05',
     headline: 'May 5',

--- a/lib/coursework.ts
+++ b/lib/coursework.ts
@@ -2,7 +2,7 @@
 // Each entry maps to one MDX file at content/coursework/<semester-slug>/<slug>.mdx,
 // rendered by app/coursework/[slug]/page.tsx (and optional sub-pages via [sub]).
 
-export type CoursePaper = {
+type CoursePaper = {
   title: string
   authors?: string
   year?: string

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -6,7 +6,7 @@ export type ProjectLike = (Project | WorkTool) & {
   slug: string
 }
 
-export function projectSlug(name: string): string {
+function projectSlug(name: string): string {
   return name
     .toLowerCase()
     .replace(/\(.+?\)/g, '')

--- a/lib/stack.ts
+++ b/lib/stack.ts
@@ -1,4 +1,4 @@
-export type StackItem = {
+type StackItem = {
   name: string
   why: string
   url?: string

--- a/lib/tag-icons.ts
+++ b/lib/tag-icons.ts
@@ -1,4 +1,4 @@
-export type TagIcon = { slug: string; label?: string }
+type TagIcon = { slug: string; label?: string }
 
 const normalize = (name: string): string =>
   name.toLowerCase().replace(/\s+/g, ' ').replace(/[._]+/g, ' ').trim()
@@ -83,7 +83,7 @@ const RAW: Record<string, TagIcon> = {
   spotify: { slug: 'spotify', label: 'Spotify' },
 }
 
-export function tagIconSlug(name: string): string | undefined {
+function tagIconSlug(name: string): string | undefined {
   return RAW[normalize(name)]?.slug
 }
 

--- a/lib/weekly-dates.ts
+++ b/lib/weekly-dates.ts
@@ -9,7 +9,7 @@ export function getIsoWeek(date: Date): { year: number; week: number } {
   return { year: d.getFullYear(), week }
 }
 
-export function pad2(n: number): string {
+function pad2(n: number): string {
   return n.toString().padStart(2, '0')
 }
 

--- a/lib/weekly-render.ts
+++ b/lib/weekly-render.ts
@@ -91,7 +91,7 @@ export type ResolvedItem = {
 
 // Normalizes a rail entry into a renderable object, deriving thumbnails and
 // source logos when the author didn't supply them.
-export function resolveItem(item: WeeklyItem): ResolvedItem {
+function resolveItem(item: WeeklyItem): ResolvedItem {
   if (typeof item === 'string') {
     return { text: item, bodyMarkdown: item }
   }


### PR DESCRIPTION
## Summary

Follow-up to #15. With `ignoreExportsUsedInFile: true` removed from `knip.json`, Knip surfaced 5 functions/consts + 3 types that were `export`ed but only used inside their defining file.

Demoted to file-local:
- `BANNERS` (lib/banners.ts)
- `projectSlug` (lib/projects.ts)
- `tagIconSlug` (lib/tag-icons.ts)
- `pad2` (lib/weekly-dates.ts)
- `resolveItem` (lib/weekly-render.ts)
- `CoursePaper` type (lib/coursework.ts)
- `StackItem` type (lib/stack.ts)
- `TagIcon` type (lib/tag-icons.ts)

Also drops the `ignoreExportsUsedInFile` shortcut so Knip's view matches reality. Knip now runs with zero findings.

## Test plan

- [x] `bun run knip` — clean (no output)
- [x] `bun run build` — passes
- [x] `bun run biome` — clean
- [x] `bun run lint` — warnings only (pre-existing)
- [x] `bun run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)