### PR TITLE
feat(home,architecture): floating This-Week card + restructured /architecture

### DIFF
--- a/app/architecture/page.tsx
+++ b/app/architecture/page.tsx
@@ -30,26 +30,117 @@ export const metadata = buildMetadata({
   ],
 })
 
-const DiagramSection = ({
-  index,
-  title,
-  description,
-  children,
-}: {
+type DiagramEntry = {
   index: string
+  id: string
   title: string
   description: string
-  children: ReactNode
-}) => (
-  <section className="mb-10">
-    <div className="border-b border-border pb-3 mb-5">
-      <p className="font-mono text-[10px] uppercase tracking-widest text-primary mb-1">
-        Diagram {index}
+  component: ReactNode
+  body?: ReactNode
+}
+
+const DIAGRAMS: DiagramEntry[] = [
+  {
+    index: '01',
+    id: 'site-map',
+    title: 'Site map',
+    description: 'Top-level routes served by the App Router.',
+    component: <SiteMapDiagram />,
+  },
+  {
+    index: '02',
+    id: 'navigation-flow',
+    title: 'Navigation flow',
+    description: 'Where the homepage links out — entry points to each major section.',
+    component: <NavigationFlowDiagram />,
+  },
+  {
+    index: '03',
+    id: 'content-pipeline',
+    title: 'Content pipeline',
+    description: 'MDX files in /content are loaded, parsed, and rendered as static pages.',
+    component: <ContentPipelineDiagram />,
+  },
+  {
+    index: '04',
+    id: 'seo-pipeline',
+    title: 'SEO pipeline',
+    description: 'Metadata, OG images, and JSON-LD layered onto every route.',
+    component: <SeoDiagram />,
+  },
+  {
+    index: '05',
+    id: 'ci-cd',
+    title: 'CI/CD pipeline',
+    description: 'From local commit through GitHub Actions to a Vercel deploy.',
+    component: <CiCdDiagram />,
+  },
+  {
+    index: '06',
+    id: 'component-hierarchy',
+    title: 'Component hierarchy',
+    description: 'How layout, sections, UI primitives, and embeds compose the page tree.',
+    component: <ComponentTreeDiagram />,
+  },
+  {
+    index: '07',
+    id: 'client-state',
+    title: 'Client state — Zustand + TanStack Query',
+    description:
+      'Two narrow client-state layers wrapped around a server-rendered app: Zustand for transient UI flags, TanStack Query for server-action lifecycle.',
+    component: <ClientStateDiagram />,
+    body: (
+      <p className="text-muted text-sm leading-relaxed max-w-2xl mt-6">
+        Almost the entire site is server-rendered. The two exceptions live inside the provider chain
+        mounted by <code className="font-mono text-[12px]">app/layout.tsx</code>:{' '}
+        <code className="font-mono text-[12px]">ClerkProvider</code> →{' '}
+        <code className="font-mono text-[12px]">Providers (QueryClient)</code> →{' '}
+        <code className="font-mono text-[12px]">ThemeProvider</code>. A single Zustand store (
+        <code className="font-mono text-[12px]">useUiStore</code>) owns the cmdk palette, mobile
+        nav, and a generic modal slot — consumed by{' '}
+        <code className="font-mono text-[12px]">Nav</code> and{' '}
+        <code className="font-mono text-[12px]">CommandPalette</code>. TanStack Query wraps the one
+        server action that mutates from the browser: the Clerk-gated weekly editor calls{' '}
+        <code className="font-mono text-[12px]">addWeeklyItem</code> through{' '}
+        <code className="font-mono text-[12px]">useMutation</code>, giving the form its
+        loading/error/success states without hand-rolling reducers.
       </p>
-      <h2 className="text-lg md:text-xl font-sans font-semibold text-text">{title}</h2>
-      <p className="text-muted text-sm mt-1 max-w-2xl">{description}</p>
+    ),
+  },
+  {
+    index: '08',
+    id: 'skills-library',
+    title: 'Skills library',
+    description:
+      '71 Claude Code skills served from flat markdown files via /skills, /skills/[slug], /skills/[slug]/raw, and /skills.json.',
+    component: <SkillsLibraryDiagram />,
+  },
+]
+
+const DiagramSection = ({ entry }: { entry: DiagramEntry }) => (
+  <section id={entry.id} className="scroll-mt-20 group">
+    <div className="flex items-baseline gap-4 mb-4">
+      <span className="font-mono text-[10px] uppercase tracking-widest text-primary/70 shrink-0 pt-1">
+        {entry.index}
+      </span>
+      <div className="min-w-0 flex-1">
+        <h2 className="text-lg md:text-xl font-sans font-semibold text-text leading-tight">
+          {entry.title}
+        </h2>
+        <p className="text-muted text-sm mt-1 max-w-2xl">{entry.description}</p>
+      </div>
+      <a
+        href={`#${entry.id}`}
+        className="font-mono text-[10px] uppercase tracking-widest text-subtle hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+        aria-label={`Anchor link for ${entry.title}`}
+      >
+        #
+      </a>
     </div>
-    <div className="bg-surface border border-border p-6">{children}</div>
+    <div className="border-l-2 border-border pl-4 md:pl-6 py-2">
+      {entry.component}
+      {entry.body}
+    </div>
   </section>
 )
 
@@ -62,7 +153,8 @@ export default function ArchitecturePage() {
       >
         ← Home
       </Link>
-      <div className="mt-8 mb-12 pb-6 border-b border-border">
+
+      <header className="mt-8 mb-10 pb-6 border-b border-border">
         <Pill className="mb-4">Architecture</Pill>
         <h1 className="text-3xl md:text-4xl font-bold text-text tracking-tight">
           How this site is built.
@@ -75,86 +167,34 @@ export default function ArchitecturePage() {
           skills library, and the client-state layer. The canonical reference for how arkashj.com is
           built.
         </p>
+      </header>
+
+      {/* TOC — jump to any diagram */}
+      <nav
+        aria-label="Diagrams"
+        className="mb-12 grid gap-2 sm:grid-cols-2 lg:grid-cols-4 bg-surface border border-border p-4"
+      >
+        {DIAGRAMS.map((d) => (
+          <a
+            key={d.id}
+            href={`#${d.id}`}
+            className="group flex items-baseline gap-2 px-2 py-1.5 hover:bg-elevated/60 transition-colors"
+          >
+            <span className="font-mono text-[10px] uppercase tracking-widest text-primary/70 shrink-0">
+              {d.index}
+            </span>
+            <span className="font-mono text-[11px] text-muted group-hover:text-primary transition-colors leading-snug">
+              {d.title}
+            </span>
+          </a>
+        ))}
+      </nav>
+
+      <div className="space-y-14">
+        {DIAGRAMS.map((d) => (
+          <DiagramSection key={d.id} entry={d} />
+        ))}
       </div>
-
-      <DiagramSection
-        index="01"
-        title="Site map"
-        description="Top-level routes served by the App Router."
-      >
-        <SiteMapDiagram />
-      </DiagramSection>
-
-      <DiagramSection
-        index="02"
-        title="Navigation flow"
-        description="Where the homepage links out — entry points to each major section."
-      >
-        <NavigationFlowDiagram />
-      </DiagramSection>
-
-      <DiagramSection
-        index="03"
-        title="Content pipeline"
-        description="MDX files in /content are loaded, parsed, and rendered as static pages."
-      >
-        <ContentPipelineDiagram />
-      </DiagramSection>
-
-      <DiagramSection
-        index="04"
-        title="SEO pipeline"
-        description="Metadata, OG images, and JSON-LD layered onto every route."
-      >
-        <SeoDiagram />
-      </DiagramSection>
-
-      <DiagramSection
-        index="05"
-        title="CI/CD pipeline"
-        description="From local commit through GitHub Actions to a Vercel deploy."
-      >
-        <CiCdDiagram />
-      </DiagramSection>
-
-      <DiagramSection
-        index="06"
-        title="Component hierarchy"
-        description="How layout, sections, UI primitives, and embeds compose the page tree."
-      >
-        <ComponentTreeDiagram />
-      </DiagramSection>
-
-      <DiagramSection
-        index="07"
-        title="Client state — Zustand + TanStack Query"
-        description="Two narrow client-state layers wrapped around a server-rendered app: Zustand for transient UI flags, TanStack Query for server-action lifecycle."
-      >
-        <ClientStateDiagram />
-        <p className="text-muted text-sm leading-relaxed max-w-2xl mt-6">
-          Almost the entire site is server-rendered. The two exceptions live inside the provider
-          chain mounted by <span className="font-mono text-[12px]">app/layout.tsx</span>:{' '}
-          <span className="font-mono text-[12px]">ClerkProvider</span> →{' '}
-          <span className="font-mono text-[12px]">Providers (QueryClient)</span> →{' '}
-          <span className="font-mono text-[12px]">ThemeProvider</span>. A single Zustand store (
-          <span className="font-mono text-[12px]">useUiStore</span>) owns the cmdk palette, mobile
-          nav, and a generic modal slot — consumed by{' '}
-          <span className="font-mono text-[12px]">Nav</span> and{' '}
-          <span className="font-mono text-[12px]">CommandPalette</span>. TanStack Query wraps the
-          one server action that mutates from the browser: the Clerk-gated weekly editor calls{' '}
-          <span className="font-mono text-[12px]">addWeeklyItem</span> through{' '}
-          <span className="font-mono text-[12px]">useMutation</span>, giving the form its
-          loading/error/success states without hand-rolling reducers.
-        </p>
-      </DiagramSection>
-
-      <DiagramSection
-        index="08"
-        title="Skills library"
-        description="71 Claude Code skills served from flat markdown files via /skills, /skills/[slug], /skills/[slug]/raw, and /skills.json."
-      >
-        <SkillsLibraryDiagram />
-      </DiagramSection>
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import PaperCard from '@/components/sections/PaperCard'
 import ProjectCard from '@/components/sections/ProjectCard'
 import RollingLog from '@/components/sections/RollingLog'
 import FeaturedBanner from '@/components/sections/FeaturedBanner'
+import ThisWeekFloat from '@/components/sections/ThisWeekFloat'
 import Card from '@/components/ui/Card'
 import TechBadge from '@/components/ui/TechBadge'
 import { PAPERS, PROJECTS } from '@/lib/data'
@@ -78,6 +79,9 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ p
           </div>
         </Card>
       </section>
+
+      {/* Floating "This Week" feature card — sits in the middle of the page */}
+      <ThisWeekFloat />
 
       {/* Research */}
       <section className="px-6 py-10 max-w-6xl mx-auto">

--- a/components/sections/ThisWeekFloat.tsx
+++ b/components/sections/ThisWeekFloat.tsx
@@ -1,0 +1,107 @@
+import Link from 'next/link'
+import Badge from '@/components/ui/Badge'
+import { getAllWeeklyLogs, getAllItems } from '@/lib/weekly'
+
+function formatDateRange(weekStart: string, weekEnd: string) {
+  // Parse YYYY-MM-DD as local-time to avoid UTC-shift off-by-one.
+  const fmt = (d: string) => {
+    const m = d.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+    if (!m) return d
+    const date = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  }
+  return `${fmt(weekStart)} → ${fmt(weekEnd)}`
+}
+
+export default function ThisWeekFloat() {
+  const [latest] = getAllWeeklyLogs()
+  if (!latest) return null
+
+  const items = getAllItems(latest)
+  const itemCount = items.length
+  const topTags = latest.tags?.slice(0, 4) ?? []
+  const previewItems = items.slice(0, 3)
+
+  return (
+    <section className="relative px-6 py-12 max-w-5xl mx-auto">
+      <div className="absolute inset-x-6 top-1/2 -translate-y-1/2 h-px bg-gradient-to-r from-transparent via-border to-transparent" />
+
+      <div className="relative">
+        <div className="absolute -inset-1 bg-gradient-to-br from-primary/15 via-accent/10 to-primary/15 blur-xl opacity-70" />
+
+        <Link
+          href={`/weekly/${latest.slug}`}
+          className="group relative block bg-surface border border-border-strong shadow-[0_25px_60px_-20px_rgba(0,0,0,0.55),0_8px_22px_-12px_rgba(94,234,212,0.18)] transition-[transform,border-color,box-shadow] duration-200 ease-out hover:-translate-y-1 hover:border-primary/60 hover:shadow-[0_30px_70px_-20px_rgba(0,0,0,0.65),0_10px_28px_-10px_rgba(94,234,212,0.28)]"
+        >
+          <div className="absolute -top-3 left-6 inline-flex items-center gap-2 bg-bg border border-primary/60 px-3 py-1">
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
+            <span className="font-mono text-[10px] uppercase tracking-widest text-primary">
+              This week in repo
+            </span>
+          </div>
+
+          <div className="p-6 md:p-8 pt-7 md:pt-9">
+            <div className="flex items-baseline justify-between gap-3 mb-3">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-primary">
+                {latest.slug}
+              </span>
+              <span className="font-mono text-[10px] text-subtle whitespace-nowrap">
+                {formatDateRange(latest.weekStart, latest.weekEnd)}
+              </span>
+            </div>
+
+            <h3 className="text-lg md:text-2xl font-bold text-text leading-tight group-hover:text-primary transition-colors duration-150 mb-3">
+              {latest.title}
+            </h3>
+
+            {latest.description && (
+              <p className="text-muted text-sm md:text-[15px] leading-relaxed line-clamp-2 mb-5">
+                {latest.description}
+              </p>
+            )}
+
+            {previewItems.length > 0 && (
+              <ul className="grid gap-1.5 mb-5">
+                {previewItems.map((item) => (
+                  <li
+                    key={item.id}
+                    className="flex items-start gap-2 text-sm text-muted line-clamp-1"
+                  >
+                    <span
+                      className="font-mono text-[9px] uppercase tracking-widest text-primary/80 mt-1 w-14 shrink-0"
+                      aria-hidden
+                    >
+                      {item.rail}
+                    </span>
+                    <span className="truncate">{item.text}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="flex items-center gap-3 flex-wrap pt-3 border-t border-border">
+              {itemCount > 0 && (
+                <span className="font-mono text-[10px] text-subtle uppercase tracking-wider">
+                  {itemCount} item{itemCount === 1 ? '' : 's'}
+                </span>
+              )}
+              {topTags.map((tag) => (
+                <Badge key={tag} variant="teal">
+                  {tag}
+                </Badge>
+              ))}
+              {(latest.tags?.length ?? 0) > 4 && (
+                <span className="font-mono text-[10px] text-subtle">
+                  +{(latest.tags?.length ?? 0) - 4} more
+                </span>
+              )}
+              <span className="ml-auto font-mono text-[10px] uppercase tracking-widest text-primary group-hover:text-accent transition-colors">
+                Read the log →
+              </span>
+            </div>
+          </div>
+        </Link>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

Two visual changes:

1. **New floating \"This week in repo\" card** on the home page, placed between The Arc summary and Research (literally in the middle of the scroll). Shows the latest weekly entry — pulsing pill, slug, date range, title, description, first 3 rail items, item count, top tags. Hover-lifts with a subtle teal glow. Timezone-safe date formatter so the range shows the actual weekStart/weekEnd days (the older RollingLog still has the off-by-one parser — left untouched).

2. **/architecture page restructured**: single `DIAGRAMS` array drives both the TOC and the body. Adds a sticky-grid TOC at the top with 4-column layout, eliminates duplicate per-diagram boilerplate, swaps the heavy bordered framing for a left-border accent on each section, and each section now has a hover-revealed anchor `#` link. Body prose for the Client-state diagram inlined into the entry.

## Test plan (via playwright-cli)

- [x] `/` — home shows 9 sections, the floating card sits at index 5 between Arc (4) and Research (6); pill reads \"THIS WEEK IN REPO\"; date displays \"May 18 → May 24\" (correct ISO W21)
- [x] `/architecture` — TOC renders 8 entries; each anchor `#site-map`, `#navigation-flow`, ..., `#skills-library` matches a `section[id]` in the body; no console errors
- [x] `/weekly`, `/weekly/2026-W21`, `/about`, `/writing`, `/skills`, `/projects`, `/research`, `/credentials` — all 200
- [x] `bun run build`, `bun run biome`, `bun run knip` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)