### PR TITLE
fix: RollingLog timezone + clear all 11 ESLint warnings

### DIFF
--- a/app/coursework/page.tsx
+++ b/app/coursework/page.tsx
@@ -5,7 +5,7 @@ import Badge from '@/components/ui/Badge'
 import TechBadge from '@/components/ui/TechBadge'
 import JsonLd from '@/components/seo/JsonLd'
 import { breadcrumbSchema } from '@/lib/structured-data'
-import { COURSES, coursesBySemester, type Course } from '@/lib/coursework'
+import { coursesBySemester, type Course } from '@/lib/coursework'
 import { buildMetadata } from '@/lib/metadata'
 
 export const metadata = buildMetadata({

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -56,8 +56,8 @@ const readmeMdxComponents = {
   hr: () => <hr className="border-border my-8" />,
   strong: (p: ComponentProps<'strong'>) => <strong className="text-text font-bold" {...p} />,
   em: (p: ComponentProps<'em'>) => <em className="text-text" {...p} />,
-  // eslint-disable-next-line @next/next/no-img-element
   img: (p: ComponentProps<'img'>) => (
+    // eslint-disable-next-line @next/next/no-img-element
     <img className="max-w-full h-auto my-4" alt={p.alt ?? ''} {...p} />
   ),
   table: (p: ComponentProps<'table'>) => (

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -37,8 +37,8 @@ const SocialIcon = ({ spec }: { spec: IconSpec }) => {
     const Icon = spec.Component
     return <Icon size={16} />
   }
-  // eslint-disable-next-line @next/next/no-img-element
   return (
+    // eslint-disable-next-line @next/next/no-img-element
     <img
       src={`https://cdn.simpleicons.org/${spec.slug}`}
       alt=""

--- a/components/sections/RollingLog.tsx
+++ b/components/sections/RollingLog.tsx
@@ -7,9 +7,11 @@ import { getAllWeeklyLogs, getAllItems } from '@/lib/weekly'
 const PAGE_SIZE = 5
 
 function formatDateRange(weekStart: string, weekEnd: string) {
+  // Parse YYYY-MM-DD as local-time to avoid UTC-shift off-by-one.
   const fmt = (d: string) => {
-    const date = new Date(d)
-    if (Number.isNaN(date.getTime())) return d
+    const m = d.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+    if (!m) return d
+    const date = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
   }
   return `${fmt(weekStart)} → ${fmt(weekEnd)}`

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -4,16 +4,16 @@ import { create } from 'zustand'
 
 type UiState = {
   paletteOpen: boolean
-  setPaletteOpen: (open: boolean) => void
+  setPaletteOpen: (_open: boolean) => void
   togglePalette: () => void
 
   mobileNavOpen: boolean
-  setMobileNavOpen: (open: boolean) => void
+  setMobileNavOpen: (_open: boolean) => void
   toggleMobileNav: () => void
 
   modalId: string | null
   modalPayload: unknown
-  openModal: (id: string, payload?: unknown) => void
+  openModal: (_id: string, _payload?: unknown) => void
   closeModal: () => void
 }
 

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -1,7 +1,7 @@
 // Frequency-rank tags across an array of items. Returns tag strings sorted
 // by count desc, alphabetical asc on ties. Used by /projects, /weekly, and
 // the git changelog UI.
-export function tagsByFrequency<T>(items: T[], pick: (item: T) => readonly string[]): string[] {
+export function tagsByFrequency<T>(items: T[], pick: (_item: T) => readonly string[]): string[] {
   const counts: Record<string, number> = {}
   for (const item of items) {
     for (const tag of pick(item)) {

--- a/lib/url-state.ts
+++ b/lib/url-state.ts
@@ -8,7 +8,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 // Empty / null values clear the param.
 export function useUrlState(keys: readonly string[]): {
   values: Record<string, string>
-  set: (key: string, value: string | null) => void
+  set: (_key: string, _value: string | null) => void
   reset: () => void
 } {
   const router = useRouter()


### PR DESCRIPTION
## Summary

Two cleanup items from the leftover-for-future note in PR #17:

1. **RollingLog timezone fix** — uses the same local-time YYYY-MM-DD parser as `ThisWeekFloat` so week ranges read `May 18 → May 24` instead of UTC-shifted `May 17 → May 23`.
2. **Zero ESLint warnings** — was 11, now 0.

### ESLint cleanup breakdown
- `lib/store.ts` (4 warnings) — prefixed type-signature param names with `_` to match the `argsIgnorePattern: "^_"` rule. Names are documentation only; no API change for consumers.
- `lib/tags.ts` (1), `lib/url-state.ts` (2) — same `_` prefix on callback type-signature params.
- `app/coursework/page.tsx` (1) — dropped unused `COURSES` import.
- `components/layout/Footer.tsx` (1), `app/projects/[slug]/page.tsx` (1) — moved the `eslint-disable-next-line @next/next/no-img-element` comment immediately above the `<img>` tag so it actually suppresses the warning.

## Test plan

- [x] playwright-cli walk: `/`, `/weekly`, `/weekly/2026-W21`, `/architecture`, `/coursework`, `/projects`, `/skills`, `/about` — all 200
- [x] Both `/` rolling-log card AND floating ThisWeek card show `May 18 → May 24` for W21
- [x] `bun run lint` — zero warnings, zero errors
- [x] `bun run build`, `bun run biome`, `bun run knip`, `bun run format:check` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)