### PR TITLE
feat: wire live GitHub stats into the GitHub Activity section

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -4,3 +4,9 @@ NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
 NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
 NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/ce-plan
 NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/ce-plan
+
+# Optional. Used by lib/github-stats.ts to fetch live 30d/7d commit counts
+# for the GitHub Activity section. Generate at
+# https://github.com/settings/tokens (fine-grained, read-only). If unset,
+# the component falls back to the hardcoded snapshot.
+GITHUB_TOKEN=

--- a/components/sections/GitHubActivity.tsx
+++ b/components/sections/GitHubActivity.tsx
@@ -7,97 +7,107 @@
 import Image from 'next/image'
 import SectionHeader from '@/components/sections/SectionHeader'
 import Card from '@/components/ui/Card'
+import { getGitHubStats } from '@/lib/github-stats'
 import { SITE } from '@/lib/site'
 
 const GH_USER = 'ArkashJ'
+
+const numberFormatter = new Intl.NumberFormat('en-US')
 
 // 53-week contribution heatmap. ghchart is canonical and dependency-free.
 // Deep GitHub green to match the standard contribution chart aesthetic.
 const CONTRIB = `https://ghchart.rshah.org/216E39/${GH_USER}`
 
-const GitHubActivity = () => (
-  <section className="px-6 py-10 max-w-6xl mx-auto">
-    <SectionHeader
-      eyebrow="GitHub"
-      title="Live activity"
-      italicAccent="Refreshed straight from the source."
-      description="Public commit cadence plus a private snapshot from a personal commit-graph tool."
-      href={SITE.social.github}
-      hrefLabel={`@${GH_USER} →`}
-    />
+const GitHubActivity = async () => {
+  const stats = await getGitHubStats()
+  const snapshotLabel = stats.live ? `Live · ${stats.asOf}` : `Snapshot · ~${stats.asOf}`
 
-    {/* Live contribution heatmap — capped width, deep green */}
-    <Card glow className="overflow-hidden">
-      <p className="font-mono text-[10px] text-primary uppercase tracking-widest mb-3">
-        Contribution graph · last 12 months
-      </p>
-      <div className="overflow-x-auto -mx-6 px-6 sm:mx-0 sm:px-0">
-        <img
-          src={CONTRIB}
-          alt={`@${GH_USER} GitHub contribution graph (last 12 months)`}
-          loading="lazy"
-          className="block mx-auto w-full max-w-3xl min-w-[520px] h-auto"
-        />
-      </div>
-    </Card>
+  return (
+    <section className="px-6 py-10 max-w-6xl mx-auto">
+      <SectionHeader
+        eyebrow="GitHub"
+        title="Live activity"
+        italicAccent="Refreshed straight from the source."
+        description="Public commit cadence plus a private snapshot from a personal commit-graph tool."
+        href={SITE.social.github}
+        hrefLabel={`@${GH_USER} →`}
+      />
 
-    {/* Snapshot table + small commit-tracker thumbnail */}
-    <div className="mt-6 grid gap-6 md:grid-cols-[1fr_320px] items-start">
-      <Card glow>
-        <p className="font-mono text-[10px] text-primary uppercase tracking-widest mb-3">
-          Snapshot · ~April 14, 2026
-        </p>
-        <ul className="space-y-3 text-sm">
-          <li className="flex items-baseline justify-between gap-3 border-b border-border pb-2">
-            <span className="text-muted text-xs uppercase tracking-widest font-mono">
-              30d commits
-            </span>
-            <span className="text-text font-bold">624</span>
-          </li>
-          <li className="flex items-baseline justify-between gap-3 border-b border-border pb-2">
-            <span className="text-muted text-xs uppercase tracking-widest font-mono">
-              7d commits
-            </span>
-            <span className="text-text font-bold">186</span>
-          </li>
-          <li className="flex items-baseline justify-between gap-3 border-b border-border pb-2">
-            <span className="text-muted text-xs uppercase tracking-widest font-mono">
-              Active days
-            </span>
-            <span className="text-text font-bold">28</span>
-          </li>
-          <li className="flex items-baseline justify-between gap-3 border-b border-border pb-2">
-            <span className="text-muted text-xs uppercase tracking-widest font-mono">
-              Raw lines
-            </span>
-            <span className="text-text font-bold">823,824</span>
-          </li>
-          <li className="flex items-baseline justify-between gap-3">
-            <span className="text-muted text-xs uppercase tracking-widest font-mono">
-              Adj output
-            </span>
-            <span className="text-primary font-bold">520,582</span>
-          </li>
-        </ul>
-        <p className="text-subtle text-[11px] font-mono mt-4 leading-relaxed">
-          Aggregated across public + private repos.
-        </p>
-      </Card>
+      {/* Live contribution heatmap — capped width, deep green */}
       <Card glow className="overflow-hidden">
         <p className="font-mono text-[10px] text-primary uppercase tracking-widest mb-3">
-          Commit-tracker · 60d
+          Contribution graph · last 12 months
         </p>
-        <Image
-          src="/assets/receipts/github-activity.png"
-          alt="Personal GitHub commit-tracker showing 624 commits in 30 days, 186 in the last 7"
-          width={794}
-          height={714}
-          className="w-full h-auto"
-          sizes="320px"
-        />
+        <div className="overflow-x-auto -mx-6 px-6 sm:mx-0 sm:px-0">
+          <img
+            src={CONTRIB}
+            alt={`@${GH_USER} GitHub contribution graph (last 12 months)`}
+            loading="lazy"
+            className="block mx-auto w-full max-w-3xl min-w-[520px] h-auto"
+          />
+        </div>
       </Card>
-    </div>
-  </section>
-)
+
+      {/* Snapshot table + small commit-tracker thumbnail */}
+      <div className="mt-6 grid gap-6 md:grid-cols-[1fr_320px] items-start">
+        <Card glow>
+          <p className="font-mono text-[10px] text-primary uppercase tracking-widest mb-3">
+            {snapshotLabel}
+          </p>
+          <ul className="space-y-3 text-sm">
+            <li className="flex items-baseline justify-between gap-3 border-b border-border pb-2">
+              <span className="text-muted text-xs uppercase tracking-widest font-mono">
+                30d commits
+              </span>
+              <span className="text-text font-bold">
+                {numberFormatter.format(stats.commits30d)}
+              </span>
+            </li>
+            <li className="flex items-baseline justify-between gap-3 border-b border-border pb-2">
+              <span className="text-muted text-xs uppercase tracking-widest font-mono">
+                7d commits
+              </span>
+              <span className="text-text font-bold">{numberFormatter.format(stats.commits7d)}</span>
+            </li>
+            <li className="flex items-baseline justify-between gap-3 border-b border-border pb-2">
+              <span className="text-muted text-xs uppercase tracking-widest font-mono">
+                Active days
+              </span>
+              <span className="text-text font-bold">{stats.activeDays}</span>
+            </li>
+            <li className="flex items-baseline justify-between gap-3 border-b border-border pb-2">
+              <span className="text-muted text-xs uppercase tracking-widest font-mono">
+                Raw lines
+              </span>
+              <span className="text-text font-bold">823,824</span>
+            </li>
+            <li className="flex items-baseline justify-between gap-3">
+              <span className="text-muted text-xs uppercase tracking-widest font-mono">
+                Adj output
+              </span>
+              <span className="text-primary font-bold">520,582</span>
+            </li>
+          </ul>
+          <p className="text-subtle text-[11px] font-mono mt-4 leading-relaxed">
+            Aggregated across public + private repos.
+          </p>
+        </Card>
+        <Card glow className="overflow-hidden">
+          <p className="font-mono text-[10px] text-primary uppercase tracking-widest mb-3">
+            Commit-tracker · 60d
+          </p>
+          <Image
+            src="/assets/receipts/github-activity.png"
+            alt="Personal GitHub commit-tracker showing 624 commits in 30 days, 186 in the last 7"
+            width={794}
+            height={714}
+            className="w-full h-auto"
+            sizes="320px"
+          />
+        </Card>
+      </div>
+    </section>
+  )
+}
 
 export default GitHubActivity


### PR DESCRIPTION
## Summary

The "Live activity" snapshot in the GitHub Activity section has been hardcoded to April 14, 2026. This PR wires it to a real GitHub GraphQL fetch.

- Adds `lib/github-stats.ts` — server-only fetcher using `contributionsCollection`, returns 30d / 7d commit counts + active days, ISR `revalidate: 3600`, graceful fallback if no `GITHUB_TOKEN` is set.
- Updates `components/sections/GitHubActivity.tsx` to be async, render live numbers, and show `Live · YYYY-MM-DD` vs `Snapshot · ~YYYY-MM-DD` based on whether the fetch succeeded.
- Documents `GITHUB_TOKEN` in `.env.local.example`.

The `Raw lines` and `Adj output` rows remain hardcoded — they come from your private commit-tracker tool, not GitHub, so the live fetch can't populate them.

## Test plan

- [ ] Set `GITHUB_TOKEN` (fine-grained, no special scopes) in Vercel env vars before merging.
- [ ] After merge + deploy: verify the snapshot label says `Live · <today>` and that the numbers update on revalidate.
- [ ] If token is unset, the section falls back to the old hardcoded snapshot — verified locally with `bunx next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)