### PR TITLE
feat: add NeoSci project, timeline entries, drop /knowledge nav

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,12 @@ bun run lint            # ESLint
 bun run lint:fix        # ESLint --fix
 bun run format          # Prettier write
 bun run format:check    # Prettier check (CI uses this)
+bun run knip            # Knip — dead-code / unused-export check (not in CI)
+bun run biome           # Biome — secondary lint/format check (not in CI)
+bun run icons:fetch     # Refetch SimpleIcons SVGs into public/assets/icons/
 ```
+
+`predev` and `prebuild` automatically run `scripts/sync-git-changelog.mjs` (and `sync-project-readmes.mjs` for prebuild), generating files under `content/_generated/` from git + project READMEs. Don't hand-edit anything inside `content/_generated/`.
 
 A Husky pre-commit hook runs **`bunx lint-staged`** (Prettier + ESLint on staged files).
 
@@ -35,31 +40,34 @@ A Husky pre-commit hook runs **`bunx lint-staged`** (Prettier + ESLint on staged
 
 All routes live under `app/`. Each folder is a segment; `page.tsx` renders that segment. Server components are the default; client components opt-in via `'use client'`.
 
-| Route                                                                        | Purpose                                                                            |
-| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `/`                                                                          | Hero · life arc · current focus · research · work · projects · knowledge · writing |
-| `/about`                                                                     | Life Changelog (17 milestones, major/minor visual hierarchy)                       |
-| `/about/timeline/[slug]`                                                     | Per-milestone deep dive                                                            |
-| `/about/archive`                                                             | Pre-revamp legacy bio                                                              |
-| `/research`                                                                  | 4 published papers + ML stack + PyTorch contribution                               |
-| `/projects`                                                                  | 13 real projects with GitHub links                                                 |
-| `/work`                                                                      | 4 internal CLIs (Foundry · RTK · Compound Skills · Excalidraw)                     |
-| `/writing` + `/writing/[slug]` + `/writing/[slug]/raw`                       | Tagged essay index + MDX articles + plaintext for LLMs                             |
-| `/weekly` + `/weekly/[slug]` + `/weekly/[slug]/raw`                          | Append-only weekly log + per-week detail + plaintext for LLMs                      |
-| `/knowledge` + `/knowledge/[domain]` + `/knowledge/[domain]/[slug]` + `/raw` | 4 domains with MDX deep dives + plaintext for LLMs                                 |
-| `/skills` + `/skills/[slug]` + `/skills/[slug]/raw`                          | "Claude Skills" library — public Claude Code skills, plaintext for copy            |
-| `/media`                                                                     | STU STREET podcast embeds + Medium + Substack + press                              |
-| `/stack`                                                                     | uses.tech-style page (36 entries × 7 categories)                                   |
-| `/learnings`                                                                 | 12+ hard-won lessons, reverse chronological                                        |
-| `/architecture`                                                              | 6 React/SVG diagrams of the running stack                                          |
-| `/changelog`                                                                 | Parsed `CHANGELOG.md` (left) + sticky commits-and-history sidebar (right)          |
-| `/admin/weekly`                                                              | Clerk-gated owner-only editor that appends to current ISO-week MDX                 |
-| `/credentials`                                                               | Verifiable PDF credentials                                                         |
-| `/coursework`                                                                | BU + Harvard coursework hub                                                        |
-| `/docs`                                                                      | In-site rendering of `docs/*.md`                                                   |
-| `/experience` · `/VC` · `/Volunteering`                                      | Server-side redirects (`/experience` → `/about#career`)                            |
-| `/knowledge/<old>/...`                                                       | 308 redirects for essays moved into `/writing` (see `next.config.js`)              |
-| `/sitemap.xml` · `/robots.txt` · `/manifest.webmanifest`                     | Native Next metadata routes                                                        |
+| Route                                                    | Purpose                                                                            |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `/`                                                      | Hero · life arc · current focus · research · work · projects · knowledge · writing |
+| `/about`                                                 | Life Changelog (17 milestones, major/minor visual hierarchy)                       |
+| `/about/timeline/[slug]`                                 | Per-milestone deep dive                                                            |
+| `/about/archive`                                         | Pre-revamp legacy bio                                                              |
+| `/research`                                              | 4 published papers + ML stack + PyTorch contribution                               |
+| `/projects`                                              | 13 real projects with GitHub links                                                 |
+| `/work`                                                  | 4 internal CLIs (Foundry · RTK · Compound Skills · Excalidraw)                     |
+| `/writing` + `/writing/[slug]` + `/writing/[slug]/raw`   | Tagged essay index + MDX articles + plaintext for LLMs                             |
+| `/weekly` + `/weekly/[slug]` + `/weekly/[slug]/raw`      | Append-only weekly log + per-week detail + plaintext for LLMs                      |
+| `/skills` + `/skills/[slug]` + `/skills/[slug]/raw`      | "Claude Skills" library — public Claude Code skills, plaintext for copy            |
+| `/media`                                                 | STU STREET podcast embeds + Medium + Substack + press                              |
+| `/stack`                                                 | uses.tech-style page (36 entries × 7 categories)                                   |
+| `/architecture`                                          | 6 React/SVG diagrams of the running stack                                          |
+| `/ai-hardware-stack`                                     | Route wrapper around the same-origin `public/ai-hardware-stack.html` deck          |
+| `/ce-plan`                                               | Continuing-education plan                                                          |
+| `/info`                                                  | About-site / colophon                                                              |
+| `/sign-in`                                               | Clerk sign-in (gates `/admin/weekly`)                                              |
+| `/api/*` · `/skills.json`                                | JSON routes (skills feed, weekly admin write endpoint, etc.)                       |
+| `/changelog`                                             | Parsed `CHANGELOG.md` (left) + sticky commits-and-history sidebar (right)          |
+| `/admin/weekly`                                          | Clerk-gated owner-only editor that appends to current ISO-week MDX                 |
+| `/credentials`                                           | Verifiable PDF credentials                                                         |
+| `/coursework`                                            | BU + Harvard coursework hub                                                        |
+| `/docs`                                                  | In-site rendering of `docs/*.md`                                                   |
+| `/experience` · `/VC` · `/Volunteering`                  | Server-side redirects (`/experience` → `/about#career`)                            |
+| `/knowledge/<old>/...`                                   | 308 redirects for essays moved into `/writing` (see `next.config.js`)              |
+| `/sitemap.xml` · `/robots.txt` · `/manifest.webmanifest` | Native Next metadata routes                                                        |
 
 ### Layout & global wrappers
 
@@ -86,28 +94,38 @@ components/
 
 All structured site content is typed and lives in `lib/`. **Edit these files to add content.**
 
-| File                     | Owns                                                                    |
-| ------------------------ | ----------------------------------------------------------------------- |
-| `lib/site.ts`            | `SITE` constants (URL, name) and `NAV_LINKS`                            |
-| `lib/data.ts`            | Papers, experience, projects, internal tools, education, awards, links  |
-| `lib/finance.ts`         | Theses + trade log                                                      |
-| `lib/learnings.ts`       | Learnings cards                                                         |
-| `lib/media.ts`           | Podcast episodes, Medium articles, Substack posts, press                |
-| `lib/stack.ts`           | uses.tech entries                                                       |
-| `lib/coursework.ts`      | BU + Harvard coursework                                                 |
-| `lib/content.ts`         | MDX frontmatter loaders for `content/writing/` and `content/knowledge/` |
-| `lib/docs.ts`            | Loaders for `docs/*.md` rendered at `/docs`                             |
-| `lib/structured-data.ts` | Person · Article · ScholarlyArticle JSON-LD factories                   |
-| `lib/metadata.ts`        | `buildMetadata()` factory typed against Next's `Metadata`               |
-| `lib/og.tsx`             | Shared 1200×630 OG image renderer                                       |
+| File                                                                                     | Owns                                                                            |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `lib/site.ts`                                                                            | `SITE` constants (URL, name) and `NAV_LINKS`                                    |
+| `lib/data.ts`                                                                            | Papers, experience, projects, internal tools, education, awards, links          |
+| `lib/projects.ts` + `lib/projects-readme.ts`                                             | Project list + README sync that feeds `content/_generated/`                     |
+| `lib/skills.ts`                                                                          | Claude Skills library entries surfaced under `/skills`                          |
+| `lib/weekly.ts` + `lib/weekly-types.ts` + `lib/weekly-render.ts` + `lib/weekly-dates.ts` | Weekly-log types, ISO-week math, icon/source resolution for `/weekly`           |
+| `lib/github-stats.ts`                                                                    | GraphQL `contributionsCollection` fetcher for the home "This week in repo" card |
+| `lib/banners.ts`                                                                         | Home/global banner picker (highest non-expired priority wins)                   |
+| `lib/tags.ts` + `lib/tag-icons.ts`                                                       | Tag taxonomy + per-tag SimpleIcons mapping                                      |
+| `lib/changelog-md.ts`                                                                    | Parses `CHANGELOG.md` for `/changelog`                                          |
+| `lib/git-changelog.ts` + `lib/git-commit.ts`                                             | Server-only readers for the synced git history sidebar                          |
+| `lib/finance.ts`                                                                         | Theses + trade log                                                              |
+| `lib/media.ts`                                                                           | Podcast episodes, Medium articles, Substack posts, press                        |
+| `lib/stack.ts`                                                                           | uses.tech entries                                                               |
+| `lib/coursework.ts`                                                                      | BU + Harvard coursework                                                         |
+| `lib/content.ts`                                                                         | MDX frontmatter loaders for `content/writing/` and other MDX surfaces           |
+| `lib/docs.ts`                                                                            | Loaders for `docs/*.md` rendered at `/docs`                                     |
+| `lib/structured-data.ts`                                                                 | Person · Article · ScholarlyArticle JSON-LD factories                           |
+| `lib/metadata.ts`                                                                        | `buildMetadata()` factory typed against Next's `Metadata`                       |
+| `lib/og.tsx`                                                                             | Shared 1200×630 OG image renderer                                               |
 
 ### Content (MDX)
 
 ```
 content/
 ├── writing/           # *.mdx — long-form essays
-├── knowledge/[domain]/# *.mdx — knowledge deep dives
-└── coursework/        # course descriptions in MDX
+├── weekly/            # *.mdx — ISO-week logs (YYYY-Www.mdx)
+├── projects/          # *.mdx — project deep-dives
+├── skills/            # *.mdx — Claude Skills library entries
+├── coursework/        # course descriptions in MDX
+└── _generated/        # auto-synced from git + project READMEs — do NOT hand-edit
 ```
 
 MDX files are picked up automatically via `lib/content.ts`. Frontmatter contract: `title`, `date`, `tags`, `description`. Server-side rendered via `next-mdx-remote/rsc` — no client JS overhead.
@@ -192,7 +210,6 @@ Reference rules:
 | New podcast / Medium / Substack / press          | `lib/media.ts`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | New thesis / trade                               | `lib/finance.ts`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | New stack entry                                  | `lib/stack.ts`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| New learning                                     | `lib/learnings.ts`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | New nav link                                     | `NAV_LINKS` in `lib/site.ts`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | New course                                       | `lib/coursework.ts` + optional MDX in `content/coursework/`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | New verifiable credential                        | Drop PDF in `public/assets/files/` + entry in `app/credentials/page.tsx`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
@@ -215,6 +232,7 @@ This site is the central evidence hub for Arkash's O-1 visa application — SEO 
 - `app/about/archive/page.tsx` is the snapshot of the pre-revamp bio. Don't accidentally edit it as the canonical about page.
 - `next.config.js` whitelists exact remote image hosts. New external image hosts require a `remotePatterns` entry.
 - `bun run build` must pass before push — CI also runs it. Lint errors fail the build.
+- Root-asset guard: `scripts/check-no-stray-root-assets.sh` rejects stray `.md`/`.png`/`.jpg`/`.gif`/`.webp`/`.pdf` at repo root (allowlist: `README.md`, `CHANGELOG.md`, `CLAUDE.md`, `LICENSE`). Route dev screenshots to `docs/screenshots/` and shipped media to `public/assets/`.
 
 ## See also
 

--- a/content/_generated/git-changelog.json
+++ b/content/_generated/git-changelog.json
@@ -1,5 +1,77 @@
 [
   {
+    "hash": "73efa9518c18b6ca8b6aa7e06d411ab7f39983f5",
+    "date": "2026-05-23T10:15:55-05:00",
+    "type": "chore",
+    "scopes": ["nav", "timeline"],
+    "summary": "drop /knowledge nav link + add Hack4Impact and Kirchhausen lab-meeting timeline entries",
+    "body": "- lib/site.ts: remove '/knowledge' from NAV_LINKS\n- lib/data.ts: add TIMELINE entries for the 2023 Hack4Impact career talk\n  and the July 2025 Kirchhausen Lab SpatialDINO presentation\n- CLAUDE.md: prettier reformatting (no content change)",
+    "tags": ["chore", "nav", "timeline"]
+  },
+  {
+    "hash": "627c96b50b33ff329dbb221a7477c505ef35165e",
+    "date": "2026-05-23T10:11:04-05:00",
+    "type": "docs",
+    "scopes": ["env"],
+    "summary": "document GITHUB_TOKEN for live stats fetcher",
+    "body": "",
+    "tags": ["docs", "env"]
+  },
+  {
+    "hash": "8e5c4181e5dbcc8440d81214f5b72d63dc5d3010",
+    "date": "2026-05-23T10:10:33-05:00",
+    "type": "feat",
+    "scopes": ["githubactivity"],
+    "summary": "wire live 30d/7d commit stats via GraphQL with fallback",
+    "body": "",
+    "tags": ["feat", "githubactivity"]
+  },
+  {
+    "hash": "a76e5b920991eb9272fc8bf9f6e17546c79d449c",
+    "date": "2026-05-23T10:09:19-05:00",
+    "type": "feat",
+    "scopes": ["lib"],
+    "summary": "add GitHub stats fetcher backed by GraphQL contributionsCollection",
+    "body": "",
+    "tags": ["feat", "lib"]
+  },
+  {
+    "hash": "d12c7e46b7a390f03133a0503e9d15ef1cc84a90",
+    "date": "2026-05-21T09:12:07-05:00",
+    "type": "fix",
+    "scopes": [],
+    "summary": "RollingLog timezone off-by-one + clear all 11 ESLint warnings",
+    "body": "RollingLog now uses the same local-time YYYY-MM-DD parser as\nThisWeekFloat so weekStart/weekEnd render as the actual ISO Monday\nand Sunday instead of UTC-shifted by one day (W21 reads 'May 18 →\nMay 24' on both cards).\n\nESLint warnings cleared from 11 → 0:\n- lib/store.ts (4) — prefixed type-signature param names with `_` so\n  they pass the `argsIgnorePattern: \"^_\"` rule. The names are\n  documentation only, no API change for consumers.\n- lib/tags.ts (1), lib/url-state.ts (2) — same `_` prefix on\n  callback type-signature params.\n- app/coursework/page.tsx (1) — dropped the unused `COURSES`\n  import; the page renders via `coursesBySemester` only.\n- components/layout/Footer.tsx (1), app/projects/[slug]/page.tsx\n  (1) — moved the `eslint-disable-next-line @next/next/no-img-element`\n  comment immediately above the `<img>` tag so it actually suppresses\n  the warning (previously it was outside the JSX return block).\n\nVerified by playwright-cli: /, /weekly, /weekly/2026-W21,\n/architecture, /coursework, /projects, /skills, /about — all 200.\n`bun run build / biome / knip / format:check / lint` all clean.\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>",
+    "tags": ["fix"]
+  },
+  {
+    "hash": "354f20f6158fcb971772d33a10d6cbe11db95667",
+    "date": "2026-05-21T09:06:52-05:00",
+    "type": "feat",
+    "scopes": ["home", "architecture"],
+    "summary": "floating \"This week in repo\" card + restructured /architecture",
+    "body": "Home page now features a prominent floating card pinned to the middle\nof the scroll (between The Arc summary and Research). Shows the\nlatest weekly entry with a pulsing \"This week in repo\" pill, slug,\ndate range, title, description, first 3 rail items, item count, and\ntop 4 tags. Lifts on hover with a subtle teal glow. Uses a\ntimezone-safe date formatter so the week range displays the actual\nweekStart day (Mon) instead of one-off-by-one (the existing\nRollingLog still has the older parser).\n\n/architecture page restructured:\n- Single DIAGRAMS array drives both the TOC and the body — eliminates\n  the duplicate per-diagram boilerplate\n- Sticky TOC at the top (4-column grid, monospaced indices) lets\n  readers jump to any diagram\n- Each diagram section has a scroll-mt-20 anchor target + hover-only\n  hash link\n- Lighter framing: left-border accent instead of the heavy bordered\n  box around each diagram\n- Body prose for the Client-state diagram inlined into the entry so\n  the layout stays consistent for diagrams 1-6 and 8\n\nVerified by playwright-cli walk: /, /weekly, /weekly/2026-W21,\n/architecture, /about, /writing, /skills, /projects, /research,\n/credentials — all 200, no console errors, TOC anchors resolve, the\nfloating card renders between sections 4 and 6 of the home scroll.\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>",
+    "tags": ["feat", "home", "architecture"]
+  },
+  {
+    "hash": "25883cc78aefc906bade404d8568a0a8952de9ba",
+    "date": "2026-05-21T09:00:10-05:00",
+    "type": "chore",
+    "scopes": ["knip"],
+    "summary": "un-export internal-only symbols across lib/",
+    "body": "Knip flagged 5 unused exports + 3 unused exported types after\nturning off the `ignoreExportsUsedInFile` shortcut. None of them\nwere imported anywhere — they were `export`ed but used only inside\ntheir defining file. Demoted to file-local:\n\n- BANNERS in lib/banners.ts\n- projectSlug in lib/projects.ts\n- tagIconSlug in lib/tag-icons.ts\n- pad2 in lib/weekly-dates.ts\n- resolveItem in lib/weekly-render.ts\n- CoursePaper type in lib/coursework.ts\n- StackItem type in lib/stack.ts\n- TagIcon type in lib/tag-icons.ts\n\nAlso drops the `ignoreExportsUsedInFile: true` shortcut from\nknip.json now that the actual surface area matches reality. Knip\nruns clean with zero findings.\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>",
+    "tags": ["chore", "knip"]
+  },
+  {
+    "hash": "b614fa4c7ce32dc704b85a2cc1d70e79682afd0a",
+    "date": "2026-05-21T08:53:18-05:00",
+    "type": "fix",
+    "scopes": ["a11y", "biome"],
+    "summary": "clear remaining Biome findings + knip binaries config",
+    "body": "Resolves every Biome finding documented in W21's built rail:\n\n- useButtonType: type=\"button\" added to close + publish buttons in\n  WeeklyGrid, ProjectDetailModal, and ce-plan/Editor\n- useAriaPropsSupportedByRole: role=\"img\" added to the star-rating\n  spans in /media so aria-label is on a valid element\n- useLiteralKeys: RAIL_DEFAULT_KIND['read'] -> RAIL_DEFAULT_KIND.read\n- noSuspiciousSemicolonInJsx: trailing ; after <code> in /info wrapped\n  as {';'} so the JSX parser stops flagging it\n- noStaticElementInteractions: CommandPalette backdrop kept as-is\n  (modal backdrop click-to-close is a documented pattern) with a\n  scoped biome-ignore comment — Escape handler in the useEffect above\n  already covers keyboard users\n\nAlso adds the two .sh scripts to knip.ignoreBinaries so Knip runs\nclean. Full pipeline now: lint, format, build, knip, and biome all\npass with zero errors.\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>",
+    "tags": ["fix", "a11y", "biome"]
+  },
+  {
     "hash": "5b5d49ac5940a1ee21edb82cb9e8a34bb638047d",
     "date": "2026-05-21T08:45:08-05:00",
     "type": "content",

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -807,6 +807,15 @@ export const TIMELINE: TimelineEntry[] = [
     slug: 'coursework-spring-2023',
   },
   {
+    title: 'Hack4Impact talk - "Navigating Your Career In Tech"',
+    org: 'Boston University',
+    category: 'Talk',
+    date: '2023',
+    status: 'Completed',
+    description:
+      'Invited talk to BU Hack4Impact on navigating a career in tech as an undergrad - the path from physics into CS + math, running VC and research internships in parallel, and how each step fed the next.',
+  },
+  {
     title: "Boston Children's Hospital - Software Engineering Intern",
     org: "Boston Children's Hospital",
     category: 'Engineering',
@@ -1018,6 +1027,22 @@ export const TIMELINE: TimelineEntry[] = [
         href: 'https://www.biorxiv.org/content/10.1101/2025.02.04.636474',
       },
       { label: 'All papers ->', href: '/research' },
+    ],
+  },
+  {
+    title: 'Kirchhausen Lab meeting - SpatialDINO presentation',
+    org: 'Harvard',
+    category: 'Talk',
+    date: 'Jul 2025',
+    status: 'Completed',
+    description:
+      'Presented "Spatial-DINO: Self Supervised, Annotation-Free 3D Modeling - Seeing is Believing" at the Kirchhausen Lab on July 15, 2025. Walked the lab through the problem statement (no general segmentation + tracking model for LLSM volumes across endosomes, viruses, mitochondria, clathrin-coated pits, nuclei, apilmods), the 3D student/teacher ViT design, KMeans content-aware cropping, NoPE, the streaming encoder, and the downstream-task benchmarks beating the prior Betzig-led approach.',
+    links: [
+      {
+        label: 'BioArxiv preprint',
+        href: 'https://www.biorxiv.org/content/10.1101/2025.02.04.636474',
+      },
+      { label: 'SpatialDINO lessons ->', href: '/writing/spatialdino-lessons' },
     ],
   },
   {

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -374,6 +374,19 @@ export const PROJECTS: Project[] = [
     ],
   },
   {
+    name: 'NeoSci - lab automation startup (YC application)',
+    year: '2024',
+    description:
+      'Independent original work outside of employment: NeoSci - "the future of science: automated, affordable, and based on ideas not resources." Applied to Y Combinator (March 2024) with a thesis that current lab automations are point automations (liquid handling, LNP synthesis, single-station rigs) and that no end-to-end solution automates an academic lab workflow from prep to analysis. Drafted a preliminary technical design for a Laboratory Robotic Assistant built on an MiR AMR base (250 kg payload, omnidirectional, SLAM-based navigation) carrying two collaborative UR arms (UR3/UR5/UR10) with Robotiq grippers + wrist camera for pick-and-place. Pitch framed around human-form limits (~8-12 hr work, two arms, chemical-exposure risk), the lack of automation democratization (only Langer-Lab-scale labs afford it), and the knowledge-transfer cost of graduating PhDs/technicians.',
+    tech: ['Robotics', 'AMR', 'SLAM', 'UR arms', 'Lab Automation', 'Hardware Design'],
+    highlights: [
+      'Authored a preliminary technical design for the robot architecture (mobility, manipulators, end effectors, vision)',
+      'Wrote the Y Combinator application end-to-end (March 2024) as solo technical founder',
+      'Identified the gap: current lab automations are point automations, not workflow automations',
+      'Targeted the academic-research market: democratize automation beyond GSK/Langer-scale labs',
+    ],
+  },
+  {
     name: 'Raft (Go)',
     year: '2023',
     description:

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -37,7 +37,6 @@ export const NAV_LINKS: NavLink[] = [
 
 // Secondary pages — surfaced in footer + gear menu, not primary nav
 export const SECONDARY_LINKS: NavLink[] = [
-  { href: '/knowledge', label: 'Knowledge' },
   { href: '/credentials', label: 'Credentials' },
   { href: '/stack', label: 'Stack' },
   { href: '/architecture', label: 'Architecture (legacy)' },


### PR DESCRIPTION
## Summary
- **NeoSci project**: adds the YC-application lab-automation startup to `/projects` with full tech stack and highlights
- **Timeline entries**: Hack4Impact career talk (2023) + Kirchhausen Lab SpatialDINO presentation (Jul 2025) with BioArxiv/writing links
- **Nav cleanup**: removes `/knowledge` link from nav bar
- **CLAUDE.md**: documentation updates reflecting current site state

## Test plan
- [ ] Verify `/projects` renders NeoSci card correctly
- [ ] Verify `/about` timeline shows both new entries in correct chronological order
- [ ] Verify nav bar no longer shows "Knowledge" link
- [ ] `bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)